### PR TITLE
Fix rounding error on order confirmation and checout on total

### DIFF
--- a/app/views/carts/_item_table.html.erb
+++ b/app/views/carts/_item_table.html.erb
@@ -19,7 +19,7 @@
           TOTAL:
         </th>
         <th>
-          <%= humanized_money_with_symbol(cart_subtotal_cents / 100) %>
+          <%= humanized_money_with_symbol(cart_subtotal_cents / 100.00) %>
         </th>
       </tr>
     </tfoot>

--- a/app/views/orders/show.html.erb
+++ b/app/views/orders/show.html.erb
@@ -45,7 +45,7 @@
                   <td></td>
                   <td>Total</td>
                   <td>
-                    <%= humanized_money_with_symbol(@order.total_cents / 100) %>
+                    <%= humanized_money_with_symbol(@order.total_cents / 100.00) %>
                   </td>
                 </tr>
               </tbody>


### PR DESCRIPTION
Fixed the weird rounding error on checkout. Still want to figure out how to make even dollar values show decimals ie. $26.00, however this will probably require reading the documentation to the money-rails gem that they installed on this project